### PR TITLE
Safe safe_remove

### DIFF
--- a/wifi_setup.sh
+++ b/wifi_setup.sh
@@ -126,7 +126,7 @@ function safe_unmount {
 
 function safe_remove {
 	if [ -d $1 ]; then 
-		rm -rf $1
+		rmdir $1
 		return $?		
 	fi
 


### PR DESCRIPTION
This PR changes the directory removing functionality as currently implemented in this software from a recursive removal of files and directories present under the mount point directory (which can be the case only on unsuccessful filesystem unmounting) to removing the directory only when it is empty (upon a successful filesystem unmounting procedure).

This closes Issue #2